### PR TITLE
Statement Object should implement the Serializable interface

### DIFF
--- a/xapi-model/src/main/java/dev/learning/xapi/model/About.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/About.java
@@ -6,6 +6,7 @@ package dev.learning.xapi.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.io.Serializable;
 import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -25,11 +26,13 @@ import lombok.Value;
 @Value
 @Builder
 @JsonInclude(Include.NON_EMPTY)
-public class About {
+public class About implements Serializable {
+
+  private static final long serialVersionUID = 1589717062268375380L;
 
   private List<String> version;
 
-  private LinkedHashMap<URI, Object> extensions;
+  private LinkedHashMap<URI, Serializable> extensions;
 
   // **Warning** do not add fields that are not required by the xAPI specification.
 

--- a/xapi-model/src/main/java/dev/learning/xapi/model/Account.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/Account.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import dev.learning.xapi.model.validation.constraints.HasScheme;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.io.Serializable;
 import java.net.URI;
 import lombok.Builder;
 import lombok.Value;
@@ -25,7 +26,9 @@ import lombok.Value;
 @Value
 @Builder
 @JsonInclude(Include.NON_EMPTY)
-public class Account {
+public class Account implements Serializable {
+
+  private static final long serialVersionUID = 3527735194079492745L;
 
   /**
    * The canonical home page for the system the account is on.

--- a/xapi-model/src/main/java/dev/learning/xapi/model/Activity.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/Activity.java
@@ -32,6 +32,8 @@ import lombok.Value;
 @EqualsAndHashCode(exclude = "definition")
 public class Activity implements StatementObject, SubStatementObject {
 
+  private static final long serialVersionUID = 4135835531245879966L;
+
   private ActivityObjectType objectType;
 
   /**

--- a/xapi-model/src/main/java/dev/learning/xapi/model/ActivityDefinition.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/ActivityDefinition.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonMerge;
 import dev.learning.xapi.model.validation.constraints.HasScheme;
+import java.io.Serializable;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +41,9 @@ import lombok.Value;
 @Value
 @Builder
 @JsonInclude(Include.NON_EMPTY)
-public class ActivityDefinition {
+public class ActivityDefinition implements Serializable {
+
+  private static final long serialVersionUID = 7290202147126019438L;
 
   /**
    * The human readable/visual name of the Activity.
@@ -107,7 +110,7 @@ public class ActivityDefinition {
    * A map of other properties as needed.
    */
   @JsonMerge
-  private Map<@HasScheme URI, Object> extensions;
+  private Map<@HasScheme URI, Serializable> extensions;
 
   // **Warning** do not add fields that are not required by the xAPI
   // specification.

--- a/xapi-model/src/main/java/dev/learning/xapi/model/ActivityState.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/ActivityState.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import dev.learning.xapi.model.validation.constraints.ValidActor;
 import dev.learning.xapi.model.validation.constraints.Variant;
 import jakarta.validation.Valid;
+import java.io.Serializable;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Value;
@@ -26,7 +27,9 @@ import lombok.Value;
 @Value
 @Builder
 @JsonInclude(Include.NON_EMPTY)
-public class ActivityState {
+public class ActivityState implements Serializable {
+
+  private static final long serialVersionUID = 5759367018015646716L;
 
   private String activityId;
 

--- a/xapi-model/src/main/java/dev/learning/xapi/model/Actor.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/Actor.java
@@ -42,6 +42,8 @@ import lombok.experimental.SuperBuilder;
 @JsonInclude(Include.NON_EMPTY)
 public abstract class Actor implements StatementObject, SubStatementObject {
 
+  private static final long serialVersionUID = 8344100941818325257L;
+
   /**
    * Full name.
    */

--- a/xapi-model/src/main/java/dev/learning/xapi/model/Agent.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/Agent.java
@@ -27,6 +27,8 @@ import lombok.experimental.SuperBuilder;
 @JsonIgnoreProperties(value = {"firstName", "lastName"})
 public class Agent extends Actor {
 
+  private static final long serialVersionUID = -2250078950427999041L;
+
   private AgentObjectType objectType;
 
   // **Warning** do not add fields that are not required by the xAPI specification.

--- a/xapi-model/src/main/java/dev/learning/xapi/model/Attachment.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/Attachment.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import dev.learning.xapi.model.validation.constraints.HasScheme;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.valueextraction.Unwrapping;
+import java.io.Serializable;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -32,7 +33,9 @@ import lombok.With;
 @Builder
 @JsonInclude(Include.NON_EMPTY)
 @EqualsAndHashCode(of = "sha2")
-public class Attachment {
+public class Attachment implements Serializable {
+
+  private static final long serialVersionUID = 3100127370407102815L;
 
   /**
    * Identifies the usage of this Attachment.

--- a/xapi-model/src/main/java/dev/learning/xapi/model/Context.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/Context.java
@@ -13,6 +13,7 @@ import dev.learning.xapi.model.validation.constraints.NotUndetermined;
 import dev.learning.xapi.model.validation.constraints.ValidActor;
 import dev.learning.xapi.model.validation.constraints.Variant;
 import jakarta.validation.Valid;
+import java.io.Serializable;
 import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -32,7 +33,9 @@ import lombok.Value;
 @Value
 @Builder
 @JsonInclude(Include.NON_EMPTY)
-public class Context {
+public class Context implements Serializable {
+
+  private static final long serialVersionUID = 1854198476180560925L;
 
   /**
    * The registration that the Statement is associated with.
@@ -87,7 +90,7 @@ public class Context {
   /**
    * A map of any other domain-specific context relevant to this Statement.
    */
-  private LinkedHashMap<@HasScheme URI, Object> extensions;
+  private LinkedHashMap<@HasScheme URI, Serializable> extensions;
 
   // **Warning** do not add fields that are not required by the xAPI specification.
 

--- a/xapi-model/src/main/java/dev/learning/xapi/model/ContextActivities.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/ContextActivities.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import jakarta.validation.Valid;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
@@ -26,7 +27,9 @@ import lombok.Value;
 @Value
 @Builder
 @JsonInclude(Include.NON_EMPTY)
-public class ContextActivities {
+public class ContextActivities implements Serializable {
+
+  private static final long serialVersionUID = -1506339427588185954L;
 
   /**
    * Activity with a direct relation to the Activity which is the Object of the Statement.

--- a/xapi-model/src/main/java/dev/learning/xapi/model/CoreStatement.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/CoreStatement.java
@@ -4,6 +4,7 @@
 
 package dev.learning.xapi.model;
 
+import java.io.Serializable;
 import java.time.Instant;
 import java.util.List;
 
@@ -12,7 +13,7 @@ import java.util.List;
  *
  * @author István Rátkai (Selindek)
  */
-public interface CoreStatement {
+public interface CoreStatement extends Serializable {
 
   /**
    * Whom the Statement is about, as an Agent or Group Object.
@@ -27,7 +28,7 @@ public interface CoreStatement {
   /**
    * Activity, Agent, or another Statement that is the Object of the Statement.
    */
-  Object getObject();
+  Serializable getObject();
 
   /**
    * Result Object, further details representing a measured outcome.

--- a/xapi-model/src/main/java/dev/learning/xapi/model/Group.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/Group.java
@@ -31,6 +31,8 @@ import lombok.experimental.SuperBuilder;
 @ToString(callSuper = true)
 public class Group extends Actor {
 
+  private static final long serialVersionUID = -8192484918456106884L;
+
   private final String objectType = "Group"; // NOSONAR
 
   /**

--- a/xapi-model/src/main/java/dev/learning/xapi/model/InteractionComponent.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/InteractionComponent.java
@@ -7,6 +7,7 @@ package dev.learning.xapi.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import jakarta.validation.constraints.NotNull;
+import java.io.Serializable;
 import java.util.Locale;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -25,7 +26,9 @@ import lombok.Value;
 @Builder
 @JsonInclude(Include.NON_EMPTY)
 @EqualsAndHashCode(of = "id")
-public class InteractionComponent {
+public class InteractionComponent implements Serializable {
+
+  private static final long serialVersionUID = 6163600666447504207L;
 
   /**
    * Identifies the interaction component within the list.

--- a/xapi-model/src/main/java/dev/learning/xapi/model/InteractionType.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/InteractionType.java
@@ -5,13 +5,14 @@
 package dev.learning.xapi.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
 
 /**
  * This enumeration class represents all valid xAPI interaction types.
  *
  * @author István Rátkai (Selindek)
  */
-public enum InteractionType {
+public enum InteractionType implements Serializable {
 
   /**
    * An interaction with two possible responses: true or false.

--- a/xapi-model/src/main/java/dev/learning/xapi/model/Person.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/Person.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.learning.xapi.model.validation.constraints.Mbox;
 import jakarta.validation.Valid;
+import java.io.Serializable;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,7 +31,9 @@ import lombok.Value;
 @Builder
 @JsonInclude(Include.NON_EMPTY)
 @JsonIgnoreProperties(value = {"firstName", "lastName"})
-public class Person {
+public class Person implements Serializable {
+
+  private static final long serialVersionUID = 7267970289744420409L;
 
   private final String objectType = "Person"; // NOSONAR
 

--- a/xapi-model/src/main/java/dev/learning/xapi/model/Result.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/Result.java
@@ -64,7 +64,7 @@ public class Result implements Serializable {
       message = "Must be a valid ISO 8601:2004 duration format.")
   private String duration;
 
-  private LinkedHashMap<@HasScheme URI, Object> extensions;
+  private LinkedHashMap<@HasScheme URI, Serializable> extensions;
 
   // **Warning** do not add fields that are not required by the xAPI specification.
 

--- a/xapi-model/src/main/java/dev/learning/xapi/model/Result.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/Result.java
@@ -10,6 +10,7 @@ import dev.learning.xapi.model.validation.constraints.HasScheme;
 import dev.learning.xapi.model.validation.constraints.VaildScore;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Pattern;
+import java.io.Serializable;
 import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.function.Consumer;
@@ -27,7 +28,9 @@ import lombok.Value;
 @Value
 @Builder
 @JsonInclude(Include.NON_EMPTY)
-public class Result {
+public class Result implements Serializable {
+
+  private static final long serialVersionUID = -6034672506802254604L;
 
   /**
    * The score of the Agent in relation to the success or quality of the experience.

--- a/xapi-model/src/main/java/dev/learning/xapi/model/Score.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/Score.java
@@ -7,6 +7,7 @@ package dev.learning.xapi.model;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import dev.learning.xapi.model.validation.constraints.ScaledScore;
+import java.io.Serializable;
 import lombok.Builder;
 import lombok.Value;
 
@@ -21,7 +22,9 @@ import lombok.Value;
 @Value
 @Builder
 @JsonInclude(Include.NON_EMPTY)
-public class Score {
+public class Score implements Serializable {
+
+  private static final long serialVersionUID = -7263428125809380113L;
 
   /**
    * The score related to the experience as modified by scaling and/or normalization.

--- a/xapi-model/src/main/java/dev/learning/xapi/model/Statement.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/Statement.java
@@ -55,6 +55,8 @@ import lombok.With;
 @EqualsAndHashCode(of = {"actor", "verb", "object", "result", "context"})
 public class Statement implements CoreStatement {
 
+  private static final long serialVersionUID = 7664949791630334169L;
+
   /**
    * UUID assigned by LRS if not set by the Learning Record Provider.
    */

--- a/xapi-model/src/main/java/dev/learning/xapi/model/Statement.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/Statement.java
@@ -15,7 +15,6 @@ import dev.learning.xapi.model.validation.constraints.ValidStatementRevision;
 import dev.learning.xapi.model.validation.constraints.ValidStatementVerb;
 import dev.learning.xapi.model.validation.constraints.Variant;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.lang.UnknownClassException;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -164,8 +163,8 @@ public class Statement implements CoreStatement {
       claims.put("context", this.context);
 
       try {
-        final var token = Jwts.builder().setClaims(claims)
-            .signWith(privateKey, SignatureAlgorithm.RS512).compact();
+        final var token =
+            Jwts.builder().claims(claims).signWith(privateKey, Jwts.SIG.RS512).compact();
 
         addAttachment(a -> a.usageType(URI.create("http://adlnet.gov/expapi/attachments/signature"))
 

--- a/xapi-model/src/main/java/dev/learning/xapi/model/StatementFormat.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/StatementFormat.java
@@ -4,12 +4,14 @@
 
 package dev.learning.xapi.model;
 
+import java.io.Serializable;
+
 /**
  * This enumeration class represents all valid Statement formats.
  *
  * @author Thomas Turrell-Croft
  */
-public enum StatementFormat {
+public enum StatementFormat implements Serializable {
 
   IDS("ids"),
 

--- a/xapi-model/src/main/java/dev/learning/xapi/model/StatementObject.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/StatementObject.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import java.io.Serializable;
 
 /**
  * This interface represents the xAPI statement object.
@@ -26,6 +27,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
     @JsonSubTypes.Type(value = Group.class, name = "Group"),
     @JsonSubTypes.Type(value = SubStatement.class, name = "SubStatement"),
     @JsonSubTypes.Type(value = StatementReference.class, name = "StatementRef")})
-public interface StatementObject {
+public interface StatementObject extends Serializable {
 
 }

--- a/xapi-model/src/main/java/dev/learning/xapi/model/StatementReference.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/StatementReference.java
@@ -23,6 +23,8 @@ import lombok.Value;
 @Builder
 public class StatementReference implements StatementObject, SubStatementObject {
 
+  private static final long serialVersionUID = -1285464528057015071L;
+
   private final String objectType = "StatementRef"; // NOSONAR
 
   /**

--- a/xapi-model/src/main/java/dev/learning/xapi/model/StatementResult.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/StatementResult.java
@@ -6,6 +6,7 @@ package dev.learning.xapi.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.io.Serializable;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +26,9 @@ import lombok.Value;
 @Value
 @Builder
 @JsonInclude(Include.NON_NULL) // Statements array could be empty
-public class StatementResult {
+public class StatementResult implements Serializable {
+
+  private static final long serialVersionUID = -8675457304395469964L;
 
   private static final URI NO_MORE = URI.create("");
 

--- a/xapi-model/src/main/java/dev/learning/xapi/model/SubStatement.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/SubStatement.java
@@ -33,6 +33,8 @@ import lombok.Value;
 @EqualsAndHashCode(exclude = {"timestamp", "attachments"})
 public class SubStatement implements StatementObject, CoreStatement {
 
+  private static final long serialVersionUID = -2319652778525572382L;
+
   private final String objectType = "SubStatement"; // NOSONAR
 
   /**

--- a/xapi-model/src/main/java/dev/learning/xapi/model/SubStatementObject.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/SubStatementObject.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import java.io.Serializable;
 
 /**
  * This interface represents the xAPI SubStatement object.
@@ -28,6 +29,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
     @JsonSubTypes.Type(value = Agent.class, name = "Agent"),
     @JsonSubTypes.Type(value = Group.class, name = "Group"),
     @JsonSubTypes.Type(value = StatementReference.class, name = "StatementRef")})
-public interface SubStatementObject {
+public interface SubStatementObject extends Serializable {
 
 }

--- a/xapi-model/src/main/java/dev/learning/xapi/model/Verb.java
+++ b/xapi-model/src/main/java/dev/learning/xapi/model/Verb.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import dev.learning.xapi.model.validation.constraints.HasScheme;
 import jakarta.validation.constraints.NotNull;
+import java.io.Serializable;
 import java.net.URI;
 import java.util.Locale;
 import lombok.AllArgsConstructor;
@@ -32,7 +33,9 @@ import lombok.With;
 @AllArgsConstructor
 @EqualsAndHashCode(of = "id")
 @JsonInclude(Include.NON_EMPTY)
-public class Verb {
+public class Verb implements Serializable {
+
+  private static final long serialVersionUID = -824710119986236174L;
 
   /**
    * Indicates the actor replied to a question, where the object is generally an activity

--- a/xapi-model/src/test/java/dev/learning/xapi/model/AboutTests.java
+++ b/xapi-model/src/test/java/dev/learning/xapi/model/AboutTests.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.is;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
@@ -117,7 +118,7 @@ class AboutTests {
   @Test
   void whenSerializingAboutWithExtensionsThenResultIsEqualToExpectedJson() throws IOException {
 
-    final var extensions = new LinkedHashMap<URI, Object>();
+    final var extensions = new LinkedHashMap<URI, Serializable>();
     extensions.put(URI.create("http://url"), "www.example.com");
 
     final var about = About.builder()
@@ -140,7 +141,7 @@ class AboutTests {
   @Test
   void whenCallingToStringThenResultIsExpected() throws IOException {
 
-    final var extensions = new LinkedHashMap<URI, Object>();
+    final var extensions = new LinkedHashMap<URI, Serializable>();
     extensions.put(URI.create("http://url"), "www.example.com");
 
     final var about = About.builder()

--- a/xapi-model/src/test/java/dev/learning/xapi/model/ActivityDefinitionTests.java
+++ b/xapi-model/src/test/java/dev/learning/xapi/model/ActivityDefinitionTests.java
@@ -16,6 +16,7 @@ import dev.learning.xapi.model.validation.constraints.HasScheme;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
@@ -36,580 +37,574 @@ import org.springframework.util.ResourceUtils;
 @DisplayName("ActivityDefinition tests")
 class ActivityDefinitionTests {
 
-    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+  private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
 
-    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+  private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
-    @Test
-    void whenDeserializingActivityDefinitionThenResultIsInstanceOfActivityDefinition()
-            throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionThenResultIsInstanceOfActivityDefinition()
+      throws Exception {
 
-        final var file =
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
+    final var file =
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
 
-        // When Deserializing ActivityDefinition
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing ActivityDefinition
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then Result Is Instance Of Activity Definition
-        assertThat(result, instanceOf(ActivityDefinition.class));
+    // Then Result Is Instance Of Activity Definition
+    assertThat(result, instanceOf(ActivityDefinition.class));
 
-    }
+  }
 
-    @Test
-    void whenDeserializingActivityDefinitionThenMoreInfoIsExpected() throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionThenMoreInfoIsExpected() throws Exception {
 
-        final var file =
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
+    final var file =
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
 
-        // When Deserializing ActivityDefinition
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing ActivityDefinition
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then MoreInfo Is Expected
-        assertThat(result.getMoreInfo(), is(URI.create("http://example.com/more")));
+    // Then MoreInfo Is Expected
+    assertThat(result.getMoreInfo(), is(URI.create("http://example.com/more")));
 
-    }
+  }
 
-    @Test
-    void whenDeserializingActivityDefinitionThenInteractionTypeIsExpected() throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionThenInteractionTypeIsExpected() throws Exception {
 
-        final var file =
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
+    final var file =
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
 
-        // When Deserializing ActivityDefinition
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing ActivityDefinition
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then InteractionType Is Expected
-        assertThat(result.getInteractionType(), is(InteractionType.TRUE_FALSE));
+    // Then InteractionType Is Expected
+    assertThat(result.getInteractionType(), is(InteractionType.TRUE_FALSE));
 
-    }
+  }
 
-    @Test
-    void whenDeserializingActivityDefinitionThenCorrectResponsesPatternIsExpected()
-            throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionThenCorrectResponsesPatternIsExpected() throws Exception {
 
-        final var file =
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
+    final var file =
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
 
-        // When Deserializing ActivityDefinition
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing ActivityDefinition
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then CorrectResponsesPattern Is Expected
-        assertThat(result.getCorrectResponsesPattern(), is(Collections.singletonList(
-                "{case_matters=false}{lang=en}To store and provide access to learning experiences.")));
+    // Then CorrectResponsesPattern Is Expected
+    assertThat(result.getCorrectResponsesPattern(), is(Collections.singletonList(
+        "{case_matters=false}{lang=en}To store and provide access to learning experiences.")));
 
-    }
+  }
 
-    @Test
-    void whenDeserializingActivityDefinitionThenExtensionsAreExpected() throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionThenExtensionsAreExpected() throws Exception {
 
-        final var file =
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
+    final var file =
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
 
-        // When Deserializing ActivityDefinition
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing ActivityDefinition
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then Extensions Are Expected
-        assertThat(result.getExtensions().get(URI.create("http://url")), is("www.example.com"));
+    // Then Extensions Are Expected
+    assertThat(result.getExtensions().get(URI.create("http://url")), is("www.example.com"));
 
-    }
+  }
 
-    @Test
-    void whenDeserializingActivityDefinitionThenNameIsExpected() throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionThenNameIsExpected() throws Exception {
 
-        final var file =
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
+    final var file =
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
 
-        // When Deserializing ActivityDefinition
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing ActivityDefinition
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then Name Is Expected
-        assertThat(result.getName().get(Locale.US),
-                is("Does the xAPI include the concept of statements?"));
+    // Then Name Is Expected
+    assertThat(result.getName().get(Locale.US),
+        is("Does the xAPI include the concept of statements?"));
 
-    }
+  }
 
-    @Test
-    void whenDeserializingActivityDefinitionThenDescriptionIsExpected() throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionThenDescriptionIsExpected() throws Exception {
 
-        final var file =
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
+    final var file =
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
 
-        // When Deserializing ActivityDefinition
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing ActivityDefinition
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then Description Is Expected
-        assertThat(result.getDescription().get(Locale.US), is("pong[.]1:[,]dg[.]:10[,]lunch[.]"));
+    // Then Description Is Expected
+    assertThat(result.getDescription().get(Locale.US), is("pong[.]1:[,]dg[.]:10[,]lunch[.]"));
 
-    }
+  }
 
-    @Test
-    void whenDeserializingActivityDefinitionThenTypeIsExpected() throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionThenTypeIsExpected() throws Exception {
 
-        final var file =
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
+    final var file =
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
 
-        // When Deserializing ActivityDefinition
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing ActivityDefinition
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then Type Is Expected
-        assertThat(result.getType(),
-                is(URI.create("http://adlnet.gov/expapi/activities/cmi.interaction")));
+    // Then Type Is Expected
+    assertThat(result.getType(),
+        is(URI.create("http://adlnet.gov/expapi/activities/cmi.interaction")));
 
-    }
+  }
 
-    @Test
-    void whenDeserializingActivityDefinitionWithoutTypeWhenDeserializedThenTypeIsNull()
-            throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionWithoutTypeWhenDeserializedThenTypeIsNull()
+      throws Exception {
 
-        final var file = ResourceUtils
-                .getFile("classpath:activity_definition/activity_definition_without_type.json");
+    final var file = ResourceUtils
+        .getFile("classpath:activity_definition/activity_definition_without_type.json");
 
-        // When Deserializing Activity Definition Without Type
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing Activity Definition Without Type
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then Type Is Null
-        assertThat(result.getType(), nullValue());
+    // Then Type Is Null
+    assertThat(result.getType(), nullValue());
 
-    }
+  }
 
-    @Test
-    void whenDeserializingActivityDefinitionWithChoicesThenChoicesIDIsExpected() throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionWithChoicesThenChoicesIDIsExpected() throws Exception {
 
-        final var file =
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
+    final var file =
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
 
-        // When Deserializing ActivityDefinition With Choices
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing ActivityDefinition With Choices
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then Choices ID Is Expected
-        assertThat(result.getChoices().get(0).getId(), is("1"));
+    // Then Choices ID Is Expected
+    assertThat(result.getChoices().get(0).getId(), is("1"));
 
-    }
+  }
 
-    @Test
-    void whenDeserializingActivityDefinitionWithChoicesThenChoicesDescriptionIsExpected()
-            throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionWithChoicesThenChoicesDescriptionIsExpected()
+      throws Exception {
 
-        final var file =
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
+    final var file =
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
 
-        // When Deserializing ActivityDefinition With Choices
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing ActivityDefinition With Choices
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then Choices Description Is Expected
-        assertThat(result.getChoices().get(0).getDescription().get(Locale.US),
-                is("Does the xAPI include the concept of statements?"));
+    // Then Choices Description Is Expected
+    assertThat(result.getChoices().get(0).getDescription().get(Locale.US),
+        is("Does the xAPI include the concept of statements?"));
 
-    }
+  }
 
-    @Test
-    void whenDeserializingActivityDefinitionWithScaledThenScaleIDIsExpected() throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionWithScaledThenScaleIDIsExpected() throws Exception {
 
-        final var file =
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
+    final var file =
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
 
-        // When Deserializing ActivityDefinition With Scaled
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing ActivityDefinition With Scaled
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then Scale ID Is Expected
-        assertThat(result.getScale().get(0).getId(), is("1"));
+    // Then Scale ID Is Expected
+    assertThat(result.getScale().get(0).getId(), is("1"));
 
-    }
+  }
 
-    @Test
-    void whenDeserializingActivityDefinitionWithScaledThenScaleDescriptionIsExpected()
-            throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionWithScaledThenScaleDescriptionIsExpected()
+      throws Exception {
 
-        final var file =
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
+    final var file =
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
 
-        // When Deserializing Activity Definition With Scaled
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing Activity Definition With Scaled
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then Scale Description Is Expected
-        assertThat(result.getScale().get(0).getDescription().get(Locale.US),
-                is("Does the xAPI include the concept of statements?"));
+    // Then Scale Description Is Expected
+    assertThat(result.getScale().get(0).getDescription().get(Locale.US),
+        is("Does the xAPI include the concept of statements?"));
 
-    }
+  }
 
-    @Test
-    void whenDeserializingActivityDefinitionWithSourceThenSourceIDIsExpected() throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionWithSourceThenSourceIDIsExpected() throws Exception {
 
-        final var file =
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
+    final var file =
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
 
-        // When Deserializing Activity Definition With Source
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing Activity Definition With Source
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then Source ID Is Expected
-        assertThat(result.getSource().get(0).getId(), is("1"));
+    // Then Source ID Is Expected
+    assertThat(result.getSource().get(0).getId(), is("1"));
 
-    }
+  }
 
-    @Test
-    void whenDeserializingActivityDefinitionWithSourceThenSourceDescriptionIsExpected()
-            throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionWithSourceThenSourceDescriptionIsExpected()
+      throws Exception {
 
-        final var file =
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
+    final var file =
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
 
-        // When Deserializing Activity Definition With Source
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing Activity Definition With Source
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then Source Description Is Expected
-        assertThat(result.getSource().get(0).getDescription().get(Locale.US),
-                is("Does the xAPI include the concept of statements?"));
+    // Then Source Description Is Expected
+    assertThat(result.getSource().get(0).getDescription().get(Locale.US),
+        is("Does the xAPI include the concept of statements?"));
 
-    }
+  }
 
-    @Test
-    void whenDeserializingActivityDefinitionWithTargetThenTargetIDIsExpected() throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionWithTargetThenTargetIDIsExpected() throws Exception {
 
-        final var file =
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
+    final var file =
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
 
-        // When Deserializing Activity Definition With Target
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing Activity Definition With Target
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then Target ID Is Expected
-        assertThat(result.getTarget().get(0).getId(), is("1"));
+    // Then Target ID Is Expected
+    assertThat(result.getTarget().get(0).getId(), is("1"));
 
-    }
+  }
 
-    @Test
-    void whenDeserializingActivityDefinitionWithTargetThenTargetDescriptionIsExpected()
-            throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionWithTargetThenTargetDescriptionIsExpected()
+      throws Exception {
 
-        final var file =
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
+    final var file =
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
 
-        // When Deserializing Activity Definition With Target
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing Activity Definition With Target
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then Target Description Is Expected
-        assertThat(result.getTarget().get(0).getDescription().get(Locale.US),
-                is("Does the xAPI include the concept of statements?"));
+    // Then Target Description Is Expected
+    assertThat(result.getTarget().get(0).getDescription().get(Locale.US),
+        is("Does the xAPI include the concept of statements?"));
 
-    }
+  }
 
-    @Test
-    void whenDeserializingActivityDefinitionWithStepsThenStepsIDIsExpected() throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionWithStepsThenStepsIDIsExpected() throws Exception {
 
-        final var file =
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
+    final var file =
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
 
-        // When Deserializing Activity Definition With Steps
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing Activity Definition With Steps
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then Steps ID Is Expected
-        assertThat(result.getSteps().get(0).getId(), is("1"));
+    // Then Steps ID Is Expected
+    assertThat(result.getSteps().get(0).getId(), is("1"));
 
-    }
+  }
 
-    @Test
-    void whenDeserializingActivityDefinitionWithStepsThenStepsDescriptionIsExpected()
-            throws Exception {
+  @Test
+  void whenDeserializingActivityDefinitionWithStepsThenStepsDescriptionIsExpected()
+      throws Exception {
 
-        final var file =
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
+    final var file =
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json");
 
-        // When Deserializing Activity Definition With Steps
-        final var result = objectMapper.readValue(file, ActivityDefinition.class);
+    // When Deserializing Activity Definition With Steps
+    final var result = objectMapper.readValue(file, ActivityDefinition.class);
 
-        // Then Steps Description Is Expected
-        assertThat(result.getSteps().get(0).getDescription().get(Locale.US),
-                is("Does the xAPI include the concept of statements?"));
+    // Then Steps Description Is Expected
+    assertThat(result.getSteps().get(0).getDescription().get(Locale.US),
+        is("Does the xAPI include the concept of statements?"));
 
-    }
+  }
 
-    @Test
-    void whenSerializingActivityDefinitionOfInteractionTypeTrueFalseThenResultIsEqualToExpectedJson()
-            throws IOException {
+  @Test
+  void whenSerializingActivityDefinitionOfInteractionTypeTrueFalseThenResultIsEqualToExpectedJson()
+      throws IOException {
 
-        final var activityDefinition = ActivityDefinition.builder()
+    final var activityDefinition = ActivityDefinition.builder()
 
-                .addName(Locale.US, "True false question")
+        .addName(Locale.US, "True false question")
 
-                .addDescription(Locale.US, "Does the xAPI include the concept of statements?")
+        .addDescription(Locale.US, "Does the xAPI include the concept of statements?")
 
-                .interactionType(InteractionType.TRUE_FALSE)
+        .interactionType(InteractionType.TRUE_FALSE)
 
-                .correctResponsesPattern(Collections.singletonList("true"))
+        .correctResponsesPattern(Collections.singletonList("true"))
 
-                .type(URI.create("http://adlnet.gov/expapi/activities/cmi.interaction"))
+        .type(URI.create("http://adlnet.gov/expapi/activities/cmi.interaction"))
 
-                .build();
+        .build();
 
-        // When Serializing Activity Definition Of InteractionType True False
-        final var result =
-                objectMapper.readTree(objectMapper.writeValueAsString(activityDefinition));
+    // When Serializing Activity Definition Of InteractionType True False
+    final var result = objectMapper.readTree(objectMapper.writeValueAsString(activityDefinition));
 
-        // Then Result Is Equal To Expected Json
-        assertThat(result, is(objectMapper
-                .readTree(ResourceUtils.getFile("classpath:activity_definition/true_false.json"))));
+    // Then Result Is Equal To Expected Json
+    assertThat(result, is(objectMapper
+        .readTree(ResourceUtils.getFile("classpath:activity_definition/true_false.json"))));
 
-    }
+  }
 
-    @Test
-    void whenSerializingActivityDefinitionOfInteractionTypeChoiceThenResultIsEqualToExpectedJson()
-            throws IOException {
+  @Test
+  void whenSerializingActivityDefinitionOfInteractionTypeChoiceThenResultIsEqualToExpectedJson()
+      throws IOException {
 
-        final var activityDefinition = ActivityDefinition.builder()
+    final var activityDefinition = ActivityDefinition.builder()
 
-                .addName(Locale.US, "Choice")
+        .addName(Locale.US, "Choice")
 
-                .addDescription(Locale.US,
-                        "Which of these prototypes are available at the beta site?")
+        .addDescription(Locale.US, "Which of these prototypes are available at the beta site?")
 
-                .interactionType(InteractionType.CHOICE)
+        .interactionType(InteractionType.CHOICE)
 
-                .correctResponsesPattern(Collections.singletonList("golf[,]tetris"))
+        .correctResponsesPattern(Collections.singletonList("golf[,]tetris"))
 
-                .addChoice(c -> c.id("golf").addDescription(Locale.US, "Golf Example"))
+        .addChoice(c -> c.id("golf").addDescription(Locale.US, "Golf Example"))
 
-                .addChoice(c -> c.id("facebook").addDescription(Locale.US, "Facebook App"))
+        .addChoice(c -> c.id("facebook").addDescription(Locale.US, "Facebook App"))
 
-                .addChoice(c -> c.id("tetris").addDescription(Locale.US, "Tetris Example"))
+        .addChoice(c -> c.id("tetris").addDescription(Locale.US, "Tetris Example"))
 
-                .addChoice(c -> c.id("scrabble").addDescription(Locale.US, "Scrabble Example"))
+        .addChoice(c -> c.id("scrabble").addDescription(Locale.US, "Scrabble Example"))
 
-                .type(URI.create("http://adlnet.gov/expapi/activities/cmi.interaction"))
+        .type(URI.create("http://adlnet.gov/expapi/activities/cmi.interaction"))
 
-                .build();
+        .build();
 
-        // When Serializing Activity Definition Of InteractionType Choice
-        final var result =
-                objectMapper.readTree(objectMapper.writeValueAsString(activityDefinition));
+    // When Serializing Activity Definition Of InteractionType Choice
+    final var result = objectMapper.readTree(objectMapper.writeValueAsString(activityDefinition));
 
-        // Then Result Is Equal To Expected Json
-        assertThat(result, is(objectMapper
-                .readTree(ResourceUtils.getFile("classpath:activity_definition/choice.json"))));
+    // Then Result Is Equal To Expected Json
+    assertThat(result, is(
+        objectMapper.readTree(ResourceUtils.getFile("classpath:activity_definition/choice.json"))));
 
-    }
+  }
 
-    @Test
-    void whenCallingToStringThenResultIsExpected() throws Exception {
+  @Test
+  void whenCallingToStringThenResultIsExpected() throws Exception {
 
-        final var activityDefinition = objectMapper.readValue(
-                ResourceUtils.getFile("classpath:activity_definition/activity_definition.json"),
-                ActivityDefinition.class);
+    final var activityDefinition = objectMapper.readValue(
+        ResourceUtils.getFile("classpath:activity_definition/activity_definition.json"),
+        ActivityDefinition.class);
 
-        // When Calling ToString
-        final var result = activityDefinition.toString();
+    // When Calling ToString
+    final var result = activityDefinition.toString();
 
-        // Then Result Is Expected
-        assertThat(result, is(
-                "ActivityDefinition(name={en_US=Does the xAPI include the concept of statements?}, description={en_US=pong[.]1:[,]dg[.]:10[,]lunch[.]}, type=http://adlnet.gov/expapi/activities/cmi.interaction, moreInfo=http://example.com/more, interactionType=TRUE_FALSE, correctResponsesPattern=[{case_matters=false}{lang=en}To store and provide access to learning experiences.], choices=[InteractionComponent(id=1, description={en_US=Does the xAPI include the concept of statements?})], scale=[InteractionComponent(id=1, description={en_US=Does the xAPI include the concept of statements?})], source=[InteractionComponent(id=1, description={en_US=Does the xAPI include the concept of statements?})], target=[InteractionComponent(id=1, description={en_US=Does the xAPI include the concept of statements?})], steps=[InteractionComponent(id=1, description={en_US=Does the xAPI include the concept of statements?})], extensions={http://url=www.example.com})"));
-    }
+    // Then Result Is Expected
+    assertThat(result, is(
+        "ActivityDefinition(name={en_US=Does the xAPI include the concept of statements?}, description={en_US=pong[.]1:[,]dg[.]:10[,]lunch[.]}, type=http://adlnet.gov/expapi/activities/cmi.interaction, moreInfo=http://example.com/more, interactionType=TRUE_FALSE, correctResponsesPattern=[{case_matters=false}{lang=en}To store and provide access to learning experiences.], choices=[InteractionComponent(id=1, description={en_US=Does the xAPI include the concept of statements?})], scale=[InteractionComponent(id=1, description={en_US=Does the xAPI include the concept of statements?})], source=[InteractionComponent(id=1, description={en_US=Does the xAPI include the concept of statements?})], target=[InteractionComponent(id=1, description={en_US=Does the xAPI include the concept of statements?})], steps=[InteractionComponent(id=1, description={en_US=Does the xAPI include the concept of statements?})], extensions={http://url=www.example.com})"));
+  }
 
-    @Test
-    void whenBuildingActivityDefinitionWithTwoNameValuesThenNameLanguageMapHasTwoEntries() {
+  @Test
+  void whenBuildingActivityDefinitionWithTwoNameValuesThenNameLanguageMapHasTwoEntries() {
 
-        // When Building ActivityDefinition With Two Name Values
-        final var activityDefinition = ActivityDefinition.builder()
+    // When Building ActivityDefinition With Two Name Values
+    final var activityDefinition = ActivityDefinition.builder()
 
-                .addName(Locale.US, "True false question")
+        .addName(Locale.US, "True false question")
 
-                .addName(Locale.GERMAN, "Richtig / Falsch-Frage")
+        .addName(Locale.GERMAN, "Richtig / Falsch-Frage")
 
-                .addDescription(Locale.US, "Does the xAPI include the concept of statements?")
+        .addDescription(Locale.US, "Does the xAPI include the concept of statements?")
 
-                .interactionType(InteractionType.TRUE_FALSE)
+        .interactionType(InteractionType.TRUE_FALSE)
 
-                .correctResponsesPattern(Collections.singletonList("true"))
+        .correctResponsesPattern(Collections.singletonList("true"))
 
-                .type(URI.create("http://adlnet.gov/expapi/activities/cmi.interaction"))
+        .type(URI.create("http://adlnet.gov/expapi/activities/cmi.interaction"))
 
-                .build();
+        .build();
 
-        // Then Name Language Map Has Two Entries
-        assertThat(activityDefinition.getName(), aMapWithSize(2));
+    // Then Name Language Map Has Two Entries
+    assertThat(activityDefinition.getName(), aMapWithSize(2));
 
-    }
+  }
 
-    @Test
-    void whenBuildingActivityDefinitionWithTwoDescriptionValuesThenDescriptionLanguageMapHasTwoEntries() {
+  @Test
+  void whenBuildingActivityDefinitionWithTwoDescriptionValuesThenDescriptionLanguageMapHasTwoEntries() {
 
-        // When Building ActivityDefinition With Two Description Values
-        final var activityDefinition = ActivityDefinition.builder()
+    // When Building ActivityDefinition With Two Description Values
+    final var activityDefinition = ActivityDefinition.builder()
 
-                .addName(Locale.US, "True false question")
+        .addName(Locale.US, "True false question")
 
-                .addDescription(Locale.US, "Does the xAPI include the concept of statements?")
+        .addDescription(Locale.US, "Does the xAPI include the concept of statements?")
 
-                .addDescription(Locale.GERMAN, "Enthält die xAPI das Konzept von Anweisungen?")
+        .addDescription(Locale.GERMAN, "Enthält die xAPI das Konzept von Anweisungen?")
 
-                .interactionType(InteractionType.TRUE_FALSE)
+        .interactionType(InteractionType.TRUE_FALSE)
 
-                .correctResponsesPattern(Collections.singletonList("true"))
+        .correctResponsesPattern(Collections.singletonList("true"))
 
-                .type(URI.create("http://adlnet.gov/expapi/activities/cmi.interaction"))
+        .type(URI.create("http://adlnet.gov/expapi/activities/cmi.interaction"))
 
-                .build();
+        .build();
 
-        // Then Description Language Map Has Two Entries
-        assertThat(activityDefinition.getDescription(), aMapWithSize(2));
+    // Then Description Language Map Has Two Entries
+    assertThat(activityDefinition.getDescription(), aMapWithSize(2));
 
-    }
+  }
 
-    @Test
-    void whenMergingActivityDefinitionsWithNamesThenMergedNameIsExpected() throws IOException {
+  @Test
+  void whenMergingActivityDefinitionsWithNamesThenMergedNameIsExpected() throws IOException {
 
-        final var activityDefinition1 =
-                ActivityDefinition.builder().addName(Locale.UK, "Colour").build();
+    final var activityDefinition1 =
+        ActivityDefinition.builder().addName(Locale.UK, "Colour").build();
 
-        final var x = objectMapper
-                .valueToTree(ActivityDefinition.builder().addName(Locale.US, "Color").build());
+    final var x =
+        objectMapper.valueToTree(ActivityDefinition.builder().addName(Locale.US, "Color").build());
 
-        final var expected = new LanguageMap();
-        expected.put(Locale.UK, "Colour");
-        expected.put(Locale.US, "Color");
+    final var expected = new LanguageMap();
+    expected.put(Locale.UK, "Colour");
+    expected.put(Locale.US, "Color");
 
-        // When Merging ActivityDefinitions With Names
-        final var merged = (ActivityDefinition) objectMapper.readerForUpdating(activityDefinition1)
-                .readValue(x);
+    // When Merging ActivityDefinitions With Names
+    final var merged =
+        (ActivityDefinition) objectMapper.readerForUpdating(activityDefinition1).readValue(x);
 
-        // Then Merged Name Is Expected
-        assertThat(merged.getName(), hasAllEntries(expected));
+    // Then Merged Name Is Expected
+    assertThat(merged.getName(), hasAllEntries(expected));
 
-    }
+  }
 
-    @Test
-    void whenMergingActivityDefinitionsWithDescriptionsThenMergedDescriptionIsExpected()
-            throws IOException {
+  @Test
+  void whenMergingActivityDefinitionsWithDescriptionsThenMergedDescriptionIsExpected()
+      throws IOException {
 
-        final var activityDefinition1 =
-                ActivityDefinition.builder().addDescription(Locale.UK, "flavour").build();
+    final var activityDefinition1 =
+        ActivityDefinition.builder().addDescription(Locale.UK, "flavour").build();
 
-        final var x = objectMapper.valueToTree(
-                ActivityDefinition.builder().addDescription(Locale.US, "flavor").build());
+    final var x = objectMapper
+        .valueToTree(ActivityDefinition.builder().addDescription(Locale.US, "flavor").build());
 
-        final var expected = new LanguageMap();
-        expected.put(Locale.UK, "flavour");
-        expected.put(Locale.US, "flavor");
+    final var expected = new LanguageMap();
+    expected.put(Locale.UK, "flavour");
+    expected.put(Locale.US, "flavor");
 
-        // When Merging ActivityDefinitions With Descriptions
-        final var merged = (ActivityDefinition) objectMapper.readerForUpdating(activityDefinition1)
-                .readValue(x);
+    // When Merging ActivityDefinitions With Descriptions
+    final var merged =
+        (ActivityDefinition) objectMapper.readerForUpdating(activityDefinition1).readValue(x);
 
-        // Then Merged Description Is Expected
-        assertThat(merged.getDescription(), hasAllEntries(expected));
+    // Then Merged Description Is Expected
+    assertThat(merged.getDescription(), hasAllEntries(expected));
 
-    }
+  }
 
-    @Test
-    void whenMergingActivityDefinitionsWithExtensionsThenMergedExtensionsAreExpected()
-            throws IOException {
+  @Test
+  void whenMergingActivityDefinitionsWithExtensionsThenMergedExtensionsAreExpected()
+      throws IOException {
 
-        final Map<@HasScheme URI, Object> extensions1 = new HashMap<>();
-        extensions1.put(URI.create("https://example.com/extensions/1"), "1");
+    final Map<@HasScheme URI, Serializable> extensions1 = new HashMap<>();
+    extensions1.put(URI.create("https://example.com/extensions/1"), "1");
 
-        final var activityDefinition1 = ActivityDefinition.builder().addName(Locale.UK, "Colour")
-                .addDescription(Locale.UK, "flavour").extensions(extensions1).build();
+    final var activityDefinition1 = ActivityDefinition.builder().addName(Locale.UK, "Colour")
+        .addDescription(Locale.UK, "flavour").extensions(extensions1).build();
 
-        final Map<@HasScheme URI, Object> extensions2 = new HashMap<>();
-        extensions2.put(URI.create("https://example.com/extensions/2"), "2");
+    final Map<@HasScheme URI, Serializable> extensions2 = new HashMap<>();
+    extensions2.put(URI.create("https://example.com/extensions/2"), "2");
 
-        final var x =
-                objectMapper.valueToTree(ActivityDefinition.builder().addName(Locale.US, "Color")
-                        .addDescription(Locale.US, "flavor").extensions(extensions2).build());
+    final var x = objectMapper.valueToTree(ActivityDefinition.builder().addName(Locale.US, "Color")
+        .addDescription(Locale.US, "flavor").extensions(extensions2).build());
 
-        final Map<@HasScheme URI, Object> expected = new HashMap<>();
-        expected.put(URI.create("https://example.com/extensions/1"), "1");
-        expected.put(URI.create("https://example.com/extensions/2"), "2");
+    final Map<@HasScheme URI, Serializable> expected = new HashMap<>();
+    expected.put(URI.create("https://example.com/extensions/1"), "1");
+    expected.put(URI.create("https://example.com/extensions/2"), "2");
 
-        // When Merging ActivityDefinitions With Extensions
-        final var merged = (ActivityDefinition) objectMapper.readerForUpdating(activityDefinition1)
-                .readValue(x);
+    // When Merging ActivityDefinitions With Extensions
+    final var merged =
+        (ActivityDefinition) objectMapper.readerForUpdating(activityDefinition1).readValue(x);
 
-        // Then Merged Extensions Are Expected
-        assertThat(merged.getExtensions(), hasAllEntries(expected));
+    // Then Merged Extensions Are Expected
+    assertThat(merged.getExtensions(), hasAllEntries(expected));
 
-    }
+  }
 
-    @Test
-    void whenMergingActivityDefinitionsWithNestedExtensionsThenMergedExtensionsAreExpected()
-            throws IOException {
+  @Test
+  void whenMergingActivityDefinitionsWithNestedExtensionsThenMergedExtensionsAreExpected()
+      throws IOException {
 
-        final Map<@HasScheme URI, Object> extensions1 = new HashMap<>();
-        extensions1.put(URI.create("https://example.com/extensions/map"),
-                new HashMap<>(Collections.singletonMap("a", "y")));
+    final Map<@HasScheme URI, Serializable> extensions1 = new HashMap<>();
+    extensions1.put(URI.create("https://example.com/extensions/map"),
+        new HashMap<>(Collections.singletonMap("a", "y")));
 
-        final var activityDefinition1 =
-                ActivityDefinition.builder().extensions(extensions1).build();
+    final var activityDefinition1 = ActivityDefinition.builder().extensions(extensions1).build();
 
-        final Map<@HasScheme URI, Object> extensions2 = new HashMap<>();
-        extensions2.put(URI.create("https://example.com/extensions/map"),
-                new HashMap<>(Collections.singletonMap("b", "z")));
+    final Map<@HasScheme URI, Serializable> extensions2 = new HashMap<>();
+    extensions2.put(URI.create("https://example.com/extensions/map"),
+        new HashMap<>(Collections.singletonMap("b", "z")));
 
-        final var x = objectMapper
-                .valueToTree(ActivityDefinition.builder().extensions(extensions2).build());
+    final var x =
+        objectMapper.valueToTree(ActivityDefinition.builder().extensions(extensions2).build());
 
-        final Map<String, String> expected = new HashMap<>();
-        expected.put("a", "y");
-        expected.put("b", "z");
+    final Map<String, String> expected = new HashMap<>();
+    expected.put("a", "y");
+    expected.put("b", "z");
 
-        // When Merging ActivityDefinitions With Nested Extensions
-        final var merged = (ActivityDefinition) objectMapper.readerForUpdating(activityDefinition1)
-                .readValue(x);
+    // When Merging ActivityDefinitions With Nested Extensions
+    final var merged =
+        (ActivityDefinition) objectMapper.readerForUpdating(activityDefinition1).readValue(x);
 
-        @SuppressWarnings("unchecked")
-        final var po = (Map<String, String>) merged.getExtensions()
-                .get(URI.create("https://example.com/extensions/map"));
+    @SuppressWarnings("unchecked")
+    final var po = (Map<String, String>) merged.getExtensions()
+        .get(URI.create("https://example.com/extensions/map"));
 
-        // Then Merged Extensions Are Expected
-        assertThat(po, hasAllEntries(expected));
+    // Then Merged Extensions Are Expected
+    assertThat(po, hasAllEntries(expected));
 
-    }
+  }
 
-    @Test
-    void whenValidatingActivityDefinitionWithTypeWithNoSchemeThenConstraintViolationsSizeIsOne() {
+  @Test
+  void whenValidatingActivityDefinitionWithTypeWithNoSchemeThenConstraintViolationsSizeIsOne() {
 
-        final var activityDefinition = ActivityDefinition.builder()
+    final var activityDefinition = ActivityDefinition.builder()
 
-                .addName(Locale.US, "True false question")
+        .addName(Locale.US, "True false question")
 
-                .addDescription(Locale.US, "Does the xAPI include the concept of statements?")
+        .addDescription(Locale.US, "Does the xAPI include the concept of statements?")
 
-                .interactionType(InteractionType.TRUE_FALSE)
+        .interactionType(InteractionType.TRUE_FALSE)
 
-                .correctResponsesPattern(Collections.singletonList("true"))
+        .correctResponsesPattern(Collections.singletonList("true"))
 
-                .type(URI.create("cmi.interaction"))
+        .type(URI.create("cmi.interaction"))
 
-                .build();
+        .build();
 
-        // When Validating ActivityDefinition With Type With No Scheme
-        final var violations = validator.validate(activityDefinition);
+    // When Validating ActivityDefinition With Type With No Scheme
+    final var violations = validator.validate(activityDefinition);
 
-        // Then Constraint Violations Size Is One
-        assertThat(violations.size(), is(1));
+    // Then Constraint Violations Size Is One
+    assertThat(violations.size(), is(1));
 
-    }
+  }
 
-    @Test
-    void whenValidatingActivityDefinitionWithMoreInfoWithNoSchemeThenConstraintViolationsSizeIsOne() {
+  @Test
+  void whenValidatingActivityDefinitionWithMoreInfoWithNoSchemeThenConstraintViolationsSizeIsOne() {
 
-        final var activityDefinition = ActivityDefinition.builder()
+    final var activityDefinition = ActivityDefinition.builder()
 
-                .addName(Locale.US, "True false question")
+        .addName(Locale.US, "True false question")
 
-                .addDescription(Locale.US, "Does the xAPI include the concept of statements?")
+        .addDescription(Locale.US, "Does the xAPI include the concept of statements?")
 
-                .interactionType(InteractionType.TRUE_FALSE)
+        .interactionType(InteractionType.TRUE_FALSE)
 
-                .correctResponsesPattern(Collections.singletonList("true"))
+        .correctResponsesPattern(Collections.singletonList("true"))
 
-                .moreInfo(URI.create("example.com/moreInfo"))
+        .moreInfo(URI.create("example.com/moreInfo"))
 
-                .build();
+        .build();
 
-        // When Validating ActivityDefinition With MoreInfo With No Scheme
-        final var violations = validator.validate(activityDefinition);
+    // When Validating ActivityDefinition With MoreInfo With No Scheme
+    final var violations = validator.validate(activityDefinition);
 
-        // Then Constraint Violations Size Is One
-        assertThat(violations.size(), is(1));
+    // Then Constraint Violations Size Is One
+    assertThat(violations.size(), is(1));
 
-    }
+  }
 
 }

--- a/xapi-model/src/test/java/dev/learning/xapi/model/ActivityTests.java
+++ b/xapi-model/src/test/java/dev/learning/xapi/model/ActivityTests.java
@@ -17,6 +17,7 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
@@ -227,7 +228,7 @@ class ActivityTests {
             Collections.singletonMap(URI.create("https://example.com/extensions/b"), "b"))))
         .build());
 
-    final Map<@HasScheme URI, Object> expected = new HashMap<>();
+    final Map<@HasScheme URI, Serializable> expected = new HashMap<>();
     expected.put(URI.create("https://example.com/extensions/a"), "a");
     expected.put(URI.create("https://example.com/extensions/b"), "b");
 

--- a/xapi-model/src/test/java/dev/learning/xapi/model/ContextTests.java
+++ b/xapi-model/src/test/java/dev/learning/xapi/model/ContextTests.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.nullValue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.Locale;
@@ -214,7 +215,7 @@ class ContextTests {
   @Test
   void whenSerializingContextThenResultIsEqualToExpectedJson() throws IOException {
 
-    final var extensions = new LinkedHashMap<URI, Object>();
+    final var extensions = new LinkedHashMap<URI, Serializable>();
     extensions.put(URI.create("http://url"), "www.example.com");
 
     final var context = Context.builder()

--- a/xapi-model/src/test/java/dev/learning/xapi/model/StatementTests.java
+++ b/xapi-model/src/test/java/dev/learning/xapi/model/StatementTests.java
@@ -32,6 +32,7 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPairGenerator;
@@ -311,7 +312,7 @@ class StatementTests {
   @Test
   void whenSerializingStatementThenResultIsEqualToExpectedJson() throws IOException {
 
-    final var extensions = new LinkedHashMap<URI, Object>();
+    final var extensions = new LinkedHashMap<URI, Serializable>();
     extensions.put(URI.create("http://name"), "Kilby");
 
 
@@ -404,7 +405,7 @@ class StatementTests {
   @Test
   void whenSerializingStatementWithEnLocaleThenResultIsEqualToExpectedJson() throws IOException {
 
-    final var extensions = new LinkedHashMap<URI, Object>();
+    final var extensions = new LinkedHashMap<URI, Serializable>();
     extensions.put(URI.create("http://name"), "Kilby");
 
     final var attachment = Attachment.builder().usageType(URI.create("http://example.com"))
@@ -658,7 +659,7 @@ class StatementTests {
   void whenBuildingStatementWithTwoAttachmentsThenAttachmentsHasTwoEntries() {
 
     // When Building Statement With Two Attachments
-    final var extensions = new LinkedHashMap<URI, Object>();
+    final var extensions = new LinkedHashMap<URI, Serializable>();
     extensions.put(URI.create("http://name"), "Kilby");
 
     final var attachment = Attachment.builder().usageType(URI.create("http://example.com"))
@@ -1364,7 +1365,7 @@ class StatementTests {
     final var keyPair = keyPairGenerator.generateKeyPair();
 
     // When Signing Statement
-    final var extensions = new LinkedHashMap<URI, Object>();
+    final var extensions = new LinkedHashMap<URI, Serializable>();
     extensions.put(URI.create("http://name"), "Kilby");
 
     final var account = Account.builder()
@@ -1441,7 +1442,7 @@ class StatementTests {
     final var keyPair = keyPairGenerator.generateKeyPair();
 
     // When Signing Statement
-    final var extensions = new LinkedHashMap<URI, Object>();
+    final var extensions = new LinkedHashMap<URI, Serializable>();
     extensions.put(URI.create("http://name"), "Kilby");
 
     final var attachment = Attachment.builder().usageType(URI.create("http://example.com"))
@@ -1534,7 +1535,7 @@ class StatementTests {
     final var keyPair = keyPairGenerator.generateKeyPair();
 
     // When Signing Statement
-    final var extensions = new LinkedHashMap<URI, Object>();
+    final var extensions = new LinkedHashMap<URI, Serializable>();
     extensions.put(URI.create("http://name"), "Kilby");
 
     final var account = Account.builder()
@@ -1613,7 +1614,7 @@ class StatementTests {
     final var keyPair = keyPairGenerator.generateKeyPair();
 
     // When Signing Statement
-    final var extensions = new LinkedHashMap<URI, Object>();
+    final var extensions = new LinkedHashMap<URI, Serializable>();
     extensions.put(URI.create("http://name"), "Kilby");
 
     final var account = Account.builder()

--- a/xapi-model/src/test/java/dev/learning/xapi/model/SubStatementTests.java
+++ b/xapi-model/src/test/java/dev/learning/xapi/model/SubStatementTests.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.learning.xapi.model.Agent.AgentObjectType;
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Collections;
@@ -270,7 +271,7 @@ class SubStatementTests {
 
         .other(Collections.singletonList(activity)).build();
 
-    final var extensions = new LinkedHashMap<URI, Object>();
+    final var extensions = new LinkedHashMap<URI, Serializable>();
     extensions.put(URI.create("http://url"), "www.example.com");
 
     final var context = Context.builder()


### PR DESCRIPTION
### What

Statement object and other objects in the Statement Object should implement the Serializable interface.

### Why

Some frameworks or libraries only accept objects that implement Serializable. (Like certain cache or database like libraries)