### PR TITLE
Update Sonatype repository URLs in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -302,11 +302,11 @@
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>
     <repository>
       <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <url>https://ossrh-staging-api.central.sonatype.com/service/local/</url>
     </repository>
   </distributionManagement>
   <profiles>


### PR DESCRIPTION
This pull request updates the Maven repository URLs in the `pom.xml` file to use the latest Sonatype endpoints for both snapshot and release deployments.

Repository configuration updates:

* Updated the `snapshotRepository` URL to `https://central.sonatype.com/repository/maven-snapshots/` to reflect the new Sonatype snapshot repository location.
* Changed the `repository` URL to `https://ossrh-staging-api.central.sonatype.com/service/local/` for deploying release artifacts to the new staging API endpoint.
