### PR TITLE
Remove version for spring-boot-jackson2 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -280,10 +280,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-jackson2</artifactId>
-      </dependency>
-      <dependency>
         <groupId>dev.learning.xapi</groupId>
         <artifactId>xapi-model</artifactId>
         <version>1.1.20-SNAPSHOT</version>

--- a/xapi-model/pom.xml
+++ b/xapi-model/pom.xml
@@ -34,17 +34,13 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-jackson2</artifactId>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
     <dependency>
       <groupId>jakarta.validation</groupId>


### PR DESCRIPTION
Removed version specification for spring-boot-jackson2 dependency.

<!--
Thank you for your pull request.
-->

# Description

<!--
Please include a summary of the change and which issue is resolved.
-->

# Checklist:

- [x] Public methods are documented
- [x] Public methods are tested
- [x] New and existing tests pass when run locally
- [x] There are no new warnings or errors

<!--
Please note, pull request can not be merged unless all status checks pass.
-->
