### PR TITLE
Add Automated Release workflow: prepare/perform Maven releases and publish draft releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   release:
     # Only run for draft releases; ignore non-draft created events
-    if: ${{ github.event.release.draft == true }}
+    if: github.event.release.draft
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
### What

Amends GitHub Actions workflow (.github/workflows/release.yml) to fully automate creating a release from a GitHub draft release and deploying artifacts to Maven Central using the Maven Release Plugin.

### Why

Automates the repetitive release steps (version bump, tag, build, sign, deploy) to reduce human error and streamline release process.
Ensures consistent release tagging (vX.Y.Z), artifact upload, and publishing of the GitHub Release.

### Key behaviour / highlights

1. Trigger: runs when a GitHub release is created, but only proceeds for draft releases.
2. Validates release tag follows vX.Y.Z format and extracts version.
3. Determines the originating branch (target_commitish) and falls back to main if missing or a SHA.
4. Uses a GitHub App token for repository push and release updates (actions/create-github-app-token).
5. Checks remote to ensure tag does not already exist before proceeding.
6. Sets up Java (Temurin JDK 25) with Maven caching and configures Maven server credentials and GPG signing.
7. Runs ./mvnw release:prepare and release:perform limited to the xapi-model, xapi-client, and xapi-model-spring-boot-starter modules.
8. Pushes release commit(s) back to the originating branch; attempts fast-forward push and uses a merge fallback when needed. Detects and fails on merge conflicts and suggests remediation.
9. Collects built artifacts and uploads them to the GitHub release using gh release upload.
10. Publishes the draft release (marks draft=false) after successful artifact upload.

### Files changed

`.github/workflows/release.yml`